### PR TITLE
be defensive with uri provided by client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 0.3.0 09/06/2019
+  * Be defensive with the URI object provided from the client
+
 ## 0.2.0 08/19/2019
   * Allow use of instrumentation library without using httprb gem
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    httprb-opentracing (0.2.0)
+    httprb-opentracing (0.3.0)
       opentracing (~> 0.5.0)
 
 GEM
@@ -66,4 +66,4 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/http/tracer.rb
+++ b/lib/http/tracer.rb
@@ -48,13 +48,18 @@ module HTTP
             if ::HTTP::Tracer.ignore_request.call(verb, uri, options)
               res = request_original(verb, uri, options)
             else
+              path, host, port = nil
+              path = parsed_uri.path if parsed_uri.respond_to?(:path)
+              host = parsed_uri.host if parsed_uri.respond_to?(:host)
+              port = parsed_uri.port if parsed_uri.respond_to?(:port)
+
               tags = {
                 'component' => 'ruby-httprb',
                 'span.kind' => 'client',
                 'http.method' => verb,
-                'http.url' => parsed_uri.path,
-                'peer.host' => parsed_uri.host,
-                'peer.port' => parsed_uri.port
+                'http.url' => path,
+                'peer.host' => host,
+                'peer.port' => port
               }
 
               tracer = ::HTTP::Tracer.tracer

--- a/lib/http/tracer/version.rb
+++ b/lib/http/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module HTTP
   module Tracer
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/http/tracer_spec.rb
+++ b/spec/http/tracer_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe HTTP::Tracer do
       )
     end
 
+    it 'handles non standard URI object from client' do
+      CustomURI = Struct.new(:host)
+      uri = CustomURI.new("localhost")
+
+      tracer = double(start_active_span: true)
+      HTTP::Tracer.instrument(tracer: tracer)
+      client = HTTP::Client.new
+
+      client.request('POST', uri)
+
+      expect(tracer).to have_received(:start_active_span).with(
+        'http.request',
+        tags: {
+          'component' => 'ruby-httprb',
+          'span.kind' => 'client',
+          'http.method' => 'POST',
+          'http.url' => nil,
+          'peer.host' => 'localhost',
+          'peer.port' => nil
+        }
+      )
+    end
+
     it 'tags the span as an error when the response is an error' do
       error = StandardError.new('500 error')
       allow(error).to receive(:status).and_return(500)


### PR DESCRIPTION
The request method can work with `URI` like classes that don't support all of the `URI` interface